### PR TITLE
Fix answer creation

### DIFF
--- a/AutomatedSurvey.Web/Controllers/AnswersController.cs
+++ b/AutomatedSurvey.Web/Controllers/AnswersController.cs
@@ -28,15 +28,13 @@ namespace AutomatedSurvey.Web.Controllers
 
         [HttpPost]
         public TwiMLResult Create(
-            [Bind(Include = "RecordingUrl,Digits,CallSid,From")]
+            [Bind(Include = "QuestionId,RecordingUrl,Digits,CallSid,From")]
             Answer answer)
         {
             _answersRepository.Create(answer);
 
             var nextQuestion = new QuestionFinder(_questionsRepository).FindNext(answer.QuestionId);
-            var response = new Response(nextQuestion).Build();
-
-            return TwiML(nextQuestion != null ? response : ExitResponse);
+            return TwiML(nextQuestion != null ? new Response(nextQuestion).Build() : ExitResponse);
         }
 
         private static TwilioResponse ExitResponse


### PR DESCRIPTION
After some clean up I accidentally removed `QuestionId` from:

```
        [HttpPost]
        public TwiMLResult Create(
            [Bind(Include = "RecordingUrl,Digits,CallSid,From")]
            Answer answer)
```

That's why there was an error when creating an `Answer`, without `QuestionId` I was trying to violate the referential integrity of the database, which is incorrect.

Additionally I fix another issue introduced after the same refactor, which was to extract a variable `refactor `for `new Response(nextQuestion).Build()`, this will throw an exception if `nextQuestion` is null.

@mplacona, if you agree with the changes made, please leave a LGTM.